### PR TITLE
Add Makefile target for diff and example .env configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+API_KEY=openapikey
+
+SYS_PROMPT=preprompt

--- a/MakeFile
+++ b/MakeFile
@@ -1,0 +1,3 @@
+
+run-diff:
+	go run cmd/agent/main.go "$$(git diff main $$(git branch --show-current))"


### PR DESCRIPTION
### Summary

This pull request introduces two updates:
1. Adds a new Makefile target to execute a diff.
2. Provides an example .env configuration file for reference.

### Changes

- Added a Makefile target to simplify running a diff operation.
- Provided an `.env.example` file to serve as a configuration template.

### Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] All existing tests