### PR TITLE
fix(budget): support non-RUB currencies in transactions

### DIFF
--- a/internal/budget/model.go
+++ b/internal/budget/model.go
@@ -21,6 +21,7 @@ type Transaction struct {
 	ID           uuid.UUID
 	Type         string // "income" | "expense"
 	Amount       float64
+	Currency     string // ISO 4217: RUB, USD, EUR, THB, ...
 	CategoryID   *uuid.UUID
 	CategoryName string
 	Description  string

--- a/internal/budget/store.go
+++ b/internal/budget/store.go
@@ -83,10 +83,13 @@ func (s *Store) AddTransaction(ctx context.Context, t Transaction) error {
 	if t.ID == uuid.Nil {
 		t.ID = uuid.New()
 	}
+	if t.Currency == "" {
+		t.Currency = "RUB"
+	}
 	_, err := s.pool.Exec(ctx, `
-		INSERT INTO budget_transaction (id, type, amount, category_id, description, transaction_date)
-		VALUES ($1, $2, $3, $4, $5, $6)
-	`, t.ID, t.Type, t.Amount, t.CategoryID, t.Description, t.Date)
+		INSERT INTO budget_transaction (id, type, amount, currency, category_id, description, transaction_date)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`, t.ID, t.Type, t.Amount, t.Currency, t.CategoryID, t.Description, t.Date)
 	if err != nil {
 		return fmt.Errorf("add transaction: %w", err)
 	}
@@ -128,7 +131,7 @@ func (s *Store) ListTransactions(ctx context.Context, f TransactionFilter) ([]Tr
 	args = append(args, limit)
 
 	query := fmt.Sprintf(`
-		SELECT t.id, t.type, t.amount, t.category_id, COALESCE(c.name, ''), t.description, t.transaction_date, t.created_at
+		SELECT t.id, t.type, t.amount, t.currency, t.category_id, COALESCE(c.name, ''), t.description, t.transaction_date, t.created_at
 		FROM budget_transaction t
 		LEFT JOIN budget_category c ON c.id = t.category_id
 		%s
@@ -145,7 +148,7 @@ func (s *Store) ListTransactions(ctx context.Context, f TransactionFilter) ([]Tr
 	var out []Transaction
 	for rows.Next() {
 		var t Transaction
-		if err := rows.Scan(&t.ID, &t.Type, &t.Amount, &t.CategoryID, &t.CategoryName, &t.Description, &t.Date, &t.CreatedAt); err != nil {
+		if err := rows.Scan(&t.ID, &t.Type, &t.Amount, &t.Currency, &t.CategoryID, &t.CategoryName, &t.Description, &t.Date, &t.CreatedAt); err != nil {
 			return nil, fmt.Errorf("scan transaction: %w", err)
 		}
 		out = append(out, t)

--- a/internal/skills/budget_skill.go
+++ b/internal/skills/budget_skill.go
@@ -92,6 +92,10 @@ func (s *BudgetSkill) Manifest() plugin.Manifest {
 						"type":        "string",
 						"description": "owe (я должен) или owed (мне должны)",
 					},
+					"currency": map[string]any{
+						"type":        "string",
+						"description": "Валюта операции: RUB (по умолчанию), USD, EUR, THB, и т.д. (ISO 4217)",
+					},
 				},
 				"required": []string{"action"},
 			},
@@ -115,6 +119,7 @@ type budgetInput struct {
 	Monthly      float64 `json:"monthly,omitempty"`
 	Counterparty string  `json:"counterparty,omitempty"`
 	Direction    string  `json:"direction,omitempty"`
+	Currency     string  `json:"currency,omitempty"`
 }
 
 // Run выполняет действие и возвращает текстовый ответ.
@@ -161,6 +166,7 @@ func (s *BudgetSkill) addTransaction(ctx context.Context, req budgetInput, typ s
 		ID:          uuid.New(),
 		Type:        typ,
 		Amount:      req.Amount,
+		Currency:    req.Currency,
 		Description: req.Description,
 		Date:        time.Now(),
 	}
@@ -236,8 +242,8 @@ func (s *BudgetSkill) listTransactions(ctx context.Context, req budgetInput) (st
 		if desc != "" {
 			desc = " — " + desc
 		}
-		fmt.Fprintf(&sb, "%s %s%.0f ₽ | %s%s | %s\n",
-			icon, sign, t.Amount, cat, desc, t.Date.Format("02.01"))
+		fmt.Fprintf(&sb, "%s %s%.0f %s | %s%s | %s\n",
+			icon, sign, t.Amount, currencySymbol(t.Currency), cat, desc, t.Date.Format("02.01"))
 	}
 	return sb.String(), nil
 }
@@ -438,7 +444,8 @@ func formatTransaction(t budget.Transaction, typ string, summary *budget.Summary
 		cat = "без категории"
 	}
 
-	result := fmt.Sprintf("%s %s записан: %.0f ₽ → %s", icon, label, t.Amount, cat)
+	cur := currencySymbol(t.Currency)
+	result := fmt.Sprintf("%s %s записан: %.0f %s → %s", icon, label, t.Amount, cur, cat)
 	if t.Description != "" {
 		result += fmt.Sprintf(" (%s)", t.Description)
 	}
@@ -502,6 +509,21 @@ func parsePeriod(s string) budget.Period {
 	from := time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, time.Local)
 	to := from.AddDate(0, 1, -1)
 	return budget.Period{From: from, To: to}
+}
+
+func currencySymbol(currency string) string {
+	switch currency {
+	case "USD":
+		return "$"
+	case "EUR":
+		return "€"
+	case "THB":
+		return "฿"
+	case "CNY":
+		return "¥"
+	default:
+		return "₽"
+	}
 }
 
 func monthsUntil(deadline time.Time) int {


### PR DESCRIPTION
## Summary
- Add `currency` field to `Transaction` model (`model.go`) and DB store — INSERT and SELECT now include the column
- New migration `00008_transaction_currency.sql` adds `currency TEXT NOT NULL DEFAULT 'RUB'` to existing table
- `budget_skill.go`: expose `currency` in LLM manifest schema, add `Currency` to `budgetInput` struct, pass it through to the transaction, and show correct symbol (₽ / $ / € / ฿ / ¥) in output

## Test plan
- [ ] Say "потратил 5 долларов на кофе" → bot replies with `$5`
- [ ] Say "потратил 160 батт" → bot replies with `฿160`
- [ ] Say "потратил 500 рублей" → still shows `₽500`
- [ ] `list_transactions` output shows correct symbol per row

🤖 Generated with [Claude Code](https://claude.com/claude-code)