### PR TITLE
feat(agent): agentic loop with multi-tool support

### DIFF
--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -11,6 +11,8 @@ import (
 	"simpleAI/internal/plugin"
 )
 
+const maxIterations = 10
+
 // Service wraps an LLM client with optional skill registry for tool calling.
 type Service struct {
 	client   core.LLM
@@ -25,44 +27,65 @@ func NewServiceWithRegistry(client core.LLM, registry *plugin.Registry) *Service
 	return &Service{client: client, registry: registry}
 }
 
-// Ask отвечает на запрос пользователя. Если registry содержит skills,
-// LLM получает инструкции по tool calling в system message (через AskWithSystem).
-// При обнаружении tool call — выполняет skill и возвращает финальный ответ LLM.
+// Ask отвечает на запрос пользователя.
+// Если registry содержит skills — запускает agentic loop:
+// LLM может вызвать один или несколько инструментов за итерацию,
+// результаты передаются обратно до получения финального текстового ответа.
 func (s *Service) Ask(ctx context.Context, input string) (string, error) {
 	if s.registry == nil || len(s.registry.List()) == 0 {
 		return s.client.Ask(ctx, input)
 	}
 
-	// Tool calling инструкции идут в system message, а не в user message.
 	toolSystemPrompt := buildToolsSystemPrompt(s.registry.List())
-	resp, err := s.client.AskWithSystem(ctx, toolSystemPrompt, input)
-	if err != nil {
-		return "", err
+
+	currentPrompt := input
+	var accumulatedResults []string
+
+	for range maxIterations {
+		resp, err := s.client.AskWithSystem(ctx, toolSystemPrompt, currentPrompt)
+		if err != nil {
+			return "", err
+		}
+
+		calls := parseToolCalls(resp)
+		if len(calls) == 0 {
+			// Финальный текстовый ответ — выходим из цикла.
+			return resp, nil
+		}
+
+		// Выполняем все tool calls последовательно.
+		for i, call := range calls {
+			result, err := s.runSkill(ctx, call)
+			if err != nil {
+				accumulatedResults = append(accumulatedResults,
+					fmt.Sprintf("[%d] %s → Ошибка: %v", i+1, call.Skill, err))
+			} else {
+				accumulatedResults = append(accumulatedResults,
+					fmt.Sprintf("[%d] %s → %s", i+1, call.Skill, result))
+			}
+		}
+
+		// Передаём накопленный контекст обратно LLM.
+		currentPrompt = fmt.Sprintf(
+			"[Исходный запрос]: %s\n\n[Результаты инструментов]:\n%s\n\nОтветь пользователю или вызови ещё инструменты если нужно.",
+			input, strings.Join(accumulatedResults, "\n"),
+		)
 	}
 
-	// Пытаемся извлечь tool call JSON из ответа.
-	call, ok := parseToolCall(resp)
-	if !ok {
-		return resp, nil
-	}
+	// Превышен лимит итераций — финальный ответ без tool calling.
+	return s.client.Ask(ctx, currentPrompt)
+}
 
+func (s *Service) runSkill(ctx context.Context, call toolCall) (string, error) {
 	skill, ok := s.registry.Get(call.Skill)
 	if !ok {
 		return "", fmt.Errorf("unknown skill: %s", call.Skill)
 	}
-
 	inputJSON, err := json.Marshal(call.Input)
 	if err != nil {
 		return "", fmt.Errorf("marshal skill input: %w", err)
 	}
-
-	result, err := skill.Run(ctx, string(inputJSON))
-	if err != nil {
-		return "", fmt.Errorf("skill %s: %w", call.Skill, err)
-	}
-
-	// Финальный ответ: LLM синтезирует ответ из результата skill.
-	return s.client.Ask(ctx, result)
+	return skill.Run(ctx, string(inputJSON))
 }
 
 type toolCall struct {
@@ -70,24 +93,12 @@ type toolCall struct {
 	Input map[string]any `json:"input"`
 }
 
-// parseToolCall пытается извлечь JSON tool call из ответа LLM.
-// Поддерживает: чистый JSON, JSON в markdown ```json``` блоке, JSON внутри текста.
-func parseToolCall(resp string) (toolCall, bool) {
-	for _, candidate := range extractJSONCandidates(resp) {
-		var call toolCall
-		if err := json.Unmarshal([]byte(candidate), &call); err == nil && call.Skill != "" {
-			return call, true
-		}
-	}
-	return toolCall{}, false
-}
-
-// extractJSONCandidates возвращает потенциальные JSON-строки из ответа LLM.
-func extractJSONCandidates(resp string) []string {
+// parseToolCalls извлекает все tool calls из ответа LLM.
+// Поддерживает: одиночный JSON-объект, JSON-массив объектов, JSON внутри markdown.
+func parseToolCalls(resp string) []toolCall {
 	trimmed := strings.TrimSpace(resp)
-	candidates := []string{trimmed}
 
-	// Извлечь из markdown code block: ```json ... ``` или ``` ... ```
+	// Извлечь из markdown code block.
 	for _, fence := range []string{"```json", "```"} {
 		start := strings.Index(trimmed, fence)
 		if start == -1 {
@@ -98,28 +109,71 @@ func extractJSONCandidates(resp string) []string {
 		if end == -1 {
 			continue
 		}
-		candidates = append(candidates, strings.TrimSpace(inner[:end]))
-	}
-
-	// Найти первый JSON-объект в тексте по { ... }
-	start := strings.Index(trimmed, "{")
-	if start != -1 {
-		end := strings.LastIndex(trimmed, "}")
-		if end > start {
-			candidates = append(candidates, trimmed[start:end+1])
+		if calls, ok := unmarshalCalls(strings.TrimSpace(inner[:end])); ok {
+			return calls
 		}
 	}
 
-	return candidates
+	// Попробовать как JSON-массив или одиночный объект напрямую.
+	if calls, ok := unmarshalCalls(trimmed); ok {
+		return calls
+	}
+
+	// Найти первый JSON-объект/массив в тексте.
+	for _, start := range []string{"[", "{"} {
+		idx := strings.Index(trimmed, start)
+		if idx == -1 {
+			continue
+		}
+		var endChar string
+		if start == "[" {
+			endChar = "]"
+		} else {
+			endChar = "}"
+		}
+		end := strings.LastIndex(trimmed, endChar)
+		if end > idx {
+			if calls, ok := unmarshalCalls(trimmed[idx : end+1]); ok {
+				return calls
+			}
+		}
+	}
+
+	return nil
+}
+
+// unmarshalCalls пробует распарсить s как []toolCall или одиночный toolCall.
+func unmarshalCalls(s string) ([]toolCall, bool) {
+	// Попробовать как массив.
+	var arr []toolCall
+	if err := json.Unmarshal([]byte(s), &arr); err == nil {
+		var valid []toolCall
+		for _, c := range arr {
+			if c.Skill != "" {
+				valid = append(valid, c)
+			}
+		}
+		if len(valid) > 0 {
+			return valid, true
+		}
+	}
+
+	// Попробовать как одиночный объект.
+	var single toolCall
+	if err := json.Unmarshal([]byte(s), &single); err == nil && single.Skill != "" {
+		return []toolCall{single}, true
+	}
+
+	return nil, false
 }
 
 // buildToolsSystemPrompt формирует дополнение к system prompt с описанием доступных tools.
 func buildToolsSystemPrompt(manifests []plugin.Manifest) string {
 	var sb strings.Builder
-	sb.WriteString("У тебя есть доступ к следующим инструментам для поиска информации.\n")
-	sb.WriteString("Если запрос пользователя требует поиска данных — ответь ТОЛЬКО валидным JSON (без markdown, без пояснений):\n")
-	sb.WriteString(`{"skill": "<id>", "input": {<параметры>}}`)
-	sb.WriteString("\n\nДоступные инструменты:\n")
+	sb.WriteString("У тебя есть доступ к инструментам. Если нужно вызвать инструмент — ответь ТОЛЬКО валидным JSON без markdown и пояснений.\n")
+	sb.WriteString("Один вызов: {\"skill\": \"<id>\", \"input\": {<параметры>}}\n")
+	sb.WriteString("Несколько вызовов за раз: [{\"skill\": \"<id>\", \"input\": {...}}, {\"skill\": \"<id>\", \"input\": {...}}]\n")
+	sb.WriteString("\nДоступные инструменты:\n")
 	for _, m := range manifests {
 		fmt.Fprintf(&sb, "- %s: %s\n", m.ID, m.Description)
 		if m.InputSchema != nil {
@@ -129,6 +183,6 @@ func buildToolsSystemPrompt(manifests []plugin.Manifest) string {
 			}
 		}
 	}
-	sb.WriteString("\nЕсли инструмент не нужен — отвечай обычным текстом.")
+	sb.WriteString("\nЕсли инструменты не нужны — отвечай обычным текстом.")
 	return sb.String()
 }

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -1,0 +1,341 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"simpleAI/internal/plugin"
+)
+
+// --- Моки ---
+
+// mockLLM реализует core.LLM для тестов.
+// responses задаются заранее и отдаются по очереди.
+type mockLLM struct {
+	responses []string
+	calls     []mockCall
+	idx       int
+}
+
+type mockCall struct {
+	systemAddition string
+	userPrompt     string
+}
+
+func (m *mockLLM) Ask(ctx context.Context, prompt string) (string, error) {
+	return m.next(prompt)
+}
+
+func (m *mockLLM) AskWithSystem(ctx context.Context, systemAddition, userPrompt string) (string, error) {
+	m.calls = append(m.calls, mockCall{systemAddition, userPrompt})
+	return m.next(userPrompt)
+}
+
+func (m *mockLLM) next(_ string) (string, error) {
+	if m.idx >= len(m.responses) {
+		return "финальный ответ", nil
+	}
+	r := m.responses[m.idx]
+	m.idx++
+	return r, nil
+}
+
+// mockSkill выполняет фиксированный ответ и записывает вызовы.
+type mockSkill struct {
+	id      string
+	result  string
+	callLog []string
+}
+
+func (ms *mockSkill) Manifest() plugin.Manifest {
+	return plugin.Manifest{ID: ms.id, Name: ms.id, Description: "test skill"}
+}
+
+func (ms *mockSkill) Run(_ context.Context, input string) (string, error) {
+	ms.callLog = append(ms.callLog, input)
+	return ms.result, nil
+}
+
+func newRegistry(t *testing.T, skills ...*mockSkill) *plugin.Registry {
+	t.Helper()
+	r := plugin.NewRegistry()
+	for _, s := range skills {
+		if err := r.Register(s); err != nil {
+			t.Fatalf("register skill %q: %v", s.id, err)
+		}
+	}
+	return r
+}
+
+// --- Тесты parseToolCalls ---
+
+func TestParseToolCalls_SingleJSON(t *testing.T) {
+	resp := `{"skill":"budget","input":{"action":"add_expense","amount":100}}`
+	calls := parseToolCalls(resp)
+	if len(calls) != 1 {
+		t.Fatalf("want 1 call, got %d", len(calls))
+	}
+	if calls[0].Skill != "budget" {
+		t.Errorf("want skill=budget, got %q", calls[0].Skill)
+	}
+}
+
+func TestParseToolCalls_JSONArray(t *testing.T) {
+	resp := `[
+		{"skill":"budget","input":{"action":"add_expense","amount":100}},
+		{"skill":"budget","input":{"action":"add_expense","amount":200}}
+	]`
+	calls := parseToolCalls(resp)
+	if len(calls) != 2 {
+		t.Fatalf("want 2 calls, got %d", len(calls))
+	}
+}
+
+func TestParseToolCalls_MarkdownCodeBlock(t *testing.T) {
+	resp := "Вот вызов:\n```json\n{\"skill\":\"budget\",\"input\":{\"action\":\"summary\"}}\n```"
+	calls := parseToolCalls(resp)
+	if len(calls) != 1 {
+		t.Fatalf("want 1 call, got %d", len(calls))
+	}
+	if calls[0].Skill != "budget" {
+		t.Errorf("want skill=budget, got %q", calls[0].Skill)
+	}
+}
+
+func TestParseToolCalls_MarkdownArrayBlock(t *testing.T) {
+	resp := "```json\n[{\"skill\":\"s1\",\"input\":{}},{\"skill\":\"s2\",\"input\":{}}]\n```"
+	calls := parseToolCalls(resp)
+	if len(calls) != 2 {
+		t.Fatalf("want 2 calls, got %d", len(calls))
+	}
+}
+
+func TestParseToolCalls_PlainText(t *testing.T) {
+	calls := parseToolCalls("Привет! Как дела?")
+	if len(calls) != 0 {
+		t.Errorf("want 0 calls, got %d", len(calls))
+	}
+}
+
+func TestParseToolCalls_JSONWithoutSkill(t *testing.T) {
+	calls := parseToolCalls(`{"foo":"bar","baz":123}`)
+	if len(calls) != 0 {
+		t.Errorf("want 0 calls (no skill field), got %d", len(calls))
+	}
+}
+
+func TestParseToolCalls_JSONEmbeddedInText(t *testing.T) {
+	resp := `Нужно вызвать инструмент: {"skill":"budget","input":{"action":"summary"}} — сделано.`
+	calls := parseToolCalls(resp)
+	if len(calls) != 1 {
+		t.Fatalf("want 1 call, got %d", len(calls))
+	}
+}
+
+// --- Тесты Service.Ask ---
+
+func TestAsk_NoRegistry_PassthroughToLLM(t *testing.T) {
+	llm := &mockLLM{responses: []string{"просто ответ"}}
+	svc := NewService(llm)
+
+	got, err := svc.Ask(context.Background(), "привет")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "просто ответ" {
+		t.Errorf("want %q, got %q", "просто ответ", got)
+	}
+}
+
+func TestAsk_NoToolCall_ReturnsLLMResponse(t *testing.T) {
+	llm := &mockLLM{responses: []string{"обычный текстовый ответ"}}
+	skill := &mockSkill{id: "budget", result: "ok"}
+	svc := NewServiceWithRegistry(llm, newRegistry(t, skill))
+
+	got, err := svc.Ask(context.Background(), "привет")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "обычный текстовый ответ" {
+		t.Errorf("got %q", got)
+	}
+	if len(skill.callLog) != 0 {
+		t.Errorf("skill should not be called, but was called %d times", len(skill.callLog))
+	}
+}
+
+func TestAsk_SingleToolCall_ThenFinalAnswer(t *testing.T) {
+	toolResp := `{"skill":"budget","input":{"action":"add_expense","amount":100}}`
+	llm := &mockLLM{responses: []string{toolResp, "Расход записан!"}}
+	skill := &mockSkill{id: "budget", result: "✅ Записан расход: 100 ₽"}
+	svc := NewServiceWithRegistry(llm, newRegistry(t, skill))
+
+	got, err := svc.Ask(context.Background(), "записи расход 100 рублей")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "Расход записан!" {
+		t.Errorf("got %q", got)
+	}
+	if len(skill.callLog) != 1 {
+		t.Errorf("want 1 skill call, got %d", len(skill.callLog))
+	}
+}
+
+func TestAsk_MultipleToolCallsInArray_AllExecuted(t *testing.T) {
+	toolResp := `[
+		{"skill":"budget","input":{"action":"add_expense","amount":100,"description":"первый"}},
+		{"skill":"budget","input":{"action":"add_expense","amount":200,"description":"второй"}},
+		{"skill":"budget","input":{"action":"add_expense","amount":300,"description":"третий"}}
+	]`
+	llm := &mockLLM{responses: []string{toolResp, "Все 3 расхода записаны!"}}
+	skill := &mockSkill{id: "budget", result: "✅ ok"}
+	svc := NewServiceWithRegistry(llm, newRegistry(t, skill))
+
+	got, err := svc.Ask(context.Background(), "запиши три расхода")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "Все 3 расхода записаны!" {
+		t.Errorf("got %q", got)
+	}
+	if len(skill.callLog) != 3 {
+		t.Errorf("want 3 skill calls, got %d", len(skill.callLog))
+	}
+}
+
+func TestAsk_MultipleIterations_SecondBatchAfterFirst(t *testing.T) {
+	firstBatch := `[
+		{"skill":"budget","input":{"action":"add_expense","amount":100}},
+		{"skill":"budget","input":{"action":"add_expense","amount":200}}
+	]`
+	secondBatch := `{"skill":"budget","input":{"action":"summary"}}`
+	llm := &mockLLM{responses: []string{firstBatch, secondBatch, "Готово, всё записано и сводка есть!"}}
+	skill := &mockSkill{id: "budget", result: "ok"}
+	svc := NewServiceWithRegistry(llm, newRegistry(t, skill))
+
+	got, err := svc.Ask(context.Background(), "запиши и покажи сводку")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "Готово, всё записано и сводка есть!" {
+		t.Errorf("got %q", got)
+	}
+	if len(skill.callLog) != 3 {
+		t.Errorf("want 3 skill calls total, got %d", len(skill.callLog))
+	}
+}
+
+func TestAsk_UnknownSkill_ErrorInResults_LoopContinues(t *testing.T) {
+	toolResp := `{"skill":"nonexistent","input":{}}`
+	llm := &mockLLM{responses: []string{toolResp, "Понял, инструмент недоступен."}}
+	skill := &mockSkill{id: "budget", result: "ok"}
+	svc := NewServiceWithRegistry(llm, newRegistry(t, skill))
+
+	got, err := svc.Ask(context.Background(), "что-то сделай")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Ошибка неизвестного скилла попадает в results и передаётся LLM, не прерывает цикл.
+	if got != "Понял, инструмент недоступен." {
+		t.Errorf("got %q", got)
+	}
+	// Второй вызов AskWithSystem должен содержать сообщение об ошибке.
+	if len(llm.calls) < 2 {
+		t.Fatalf("expected at least 2 LLM calls, got %d", len(llm.calls))
+	}
+	if !strings.Contains(llm.calls[1].userPrompt, "Ошибка") {
+		t.Errorf("second LLM call should mention error, got: %q", llm.calls[1].userPrompt)
+	}
+}
+
+func TestAsk_MaxIterationsReached_ReturnsFinalAnswer(t *testing.T) {
+	// LLM всегда возвращает tool call — проверяем что цикл не бесконечный.
+	infiniteCall := `{"skill":"budget","input":{"action":"summary"}}`
+	responses := make([]string, maxIterations+2)
+	for i := range responses {
+		responses[i] = infiniteCall
+	}
+	llm := &mockLLM{responses: responses}
+	skill := &mockSkill{id: "budget", result: "ok"}
+	svc := NewServiceWithRegistry(llm, newRegistry(t, skill))
+
+	_, err := svc.Ask(context.Background(), "бесконечный цикл")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skill.callLog) != maxIterations {
+		t.Errorf("want exactly %d skill calls (maxIterations), got %d", maxIterations, len(skill.callLog))
+	}
+}
+
+func TestAsk_ResultsPassedBackToLLM(t *testing.T) {
+	toolResp := `{"skill":"budget","input":{"action":"summary"}}`
+	llm := &mockLLM{responses: []string{toolResp, "ок"}}
+	skill := &mockSkill{id: "budget", result: "Баланс: 1000 ₽"}
+	svc := NewServiceWithRegistry(llm, newRegistry(t, skill))
+
+	_, err := svc.Ask(context.Background(), "покажи сводку")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Второй вызов LLM должен содержать результат skill.
+	if len(llm.calls) < 2 {
+		t.Fatalf("expected 2 LLM calls, got %d", len(llm.calls))
+	}
+	if !strings.Contains(llm.calls[1].userPrompt, "Баланс: 1000 ₽") {
+		t.Errorf("skill result should be in second LLM call, got: %q", llm.calls[1].userPrompt)
+	}
+}
+
+// --- Тест buildToolsSystemPrompt ---
+
+func TestBuildToolsSystemPrompt_ContainsSkillInfo(t *testing.T) {
+	manifests := []plugin.Manifest{
+		{ID: "budget", Name: "Budget", Description: "Учёт финансов"},
+	}
+	prompt := buildToolsSystemPrompt(manifests)
+
+	for _, want := range []string{"budget", "Учёт финансов", "skill", "input"} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt should contain %q", want)
+		}
+	}
+}
+
+func TestBuildToolsSystemPrompt_MentionsArraySyntax(t *testing.T) {
+	prompt := buildToolsSystemPrompt([]plugin.Manifest{{ID: "x", Description: "y"}})
+	if !strings.Contains(prompt, "[{") {
+		t.Errorf("prompt should mention array syntax for multiple calls, got: %q", prompt)
+	}
+}
+
+// --- Тест контекста ---
+
+func TestAsk_ContextCancelled_ReturnsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // отменяем сразу
+
+	llm := &mockLLM{}
+	llm.responses = []string{"ок"}
+	// Оборачиваем в LLM который проверяет контекст.
+	cancellableLLM := &contextCheckLLM{ctx: ctx}
+	skill := &mockSkill{id: "budget", result: "ok"}
+	svc := NewServiceWithRegistry(cancellableLLM, newRegistry(t, skill))
+
+	_, err := svc.Ask(ctx, "запрос")
+	if err == nil {
+		t.Error("expected error for cancelled context")
+	}
+}
+
+type contextCheckLLM struct{ ctx context.Context }
+
+func (c *contextCheckLLM) Ask(ctx context.Context, _ string) (string, error) {
+	return "", ctx.Err()
+}
+func (c *contextCheckLLM) AskWithSystem(ctx context.Context, _, _ string) (string, error) {
+	return "", fmt.Errorf("context: %w", ctx.Err())
+}


### PR DESCRIPTION
## Problem
При отправке нескольких записей подряд агент выполнял только первый tool call, остальные молча игнорировались. Причина: цикла не было — один вызов LLM → один tool call → финальный ответ.

## Solution
Полный agentic loop:
1. LLM возвращает один JSON **или** JSON-массив с несколькими tool calls
2. Все вызовы выполняются последовательно, результаты накапливаются
3. Результаты передаются обратно LLM — он может сделать ещё вызовы или дать финальный ответ
4. Повторяется до получения текстового ответа или `maxIterations = 10`

System prompt обновлён: LLM теперь знает синтаксис массива `[{...}, {...}]` для пакетных операций.

## Tests (18 штук)
- `parseToolCalls`: одиночный JSON, массив, markdown блок, массив в markdown, plain text, JSON без skill, JSON внутри текста
- `Service.Ask`: без registry, без tool calls, одиночный вызов, массив из 3 вызовов, несколько итераций, неизвестный скилл (не прерывает цикл), лимит итераций, результаты передаются обратно, отмена контекста

## Test plan
- [ ] Отправить 4 записи из чека одним сообщением → все 4 должны записаться
- [ ] Обычный вопрос без бюджета → работает как раньше
- [ ] Один расход → работает как раньше

🤖 Generated with [Claude Code](https://claude.com/claude-code)