### PR TITLE
fix(budget): use specified date when adding transactions

### DIFF
--- a/internal/skills/budget_skill.go
+++ b/internal/skills/budget_skill.go
@@ -106,7 +106,7 @@ func (s *BudgetSkill) Manifest() plugin.Manifest {
 					},
 					"date": map[string]any{
 						"type":        "string",
-						"description": "Дата транзакции YYYY-MM-DD (для edit_transaction)",
+						"description": "Дата транзакции в формате YYYY-MM-DD или DD.MM.YYYY. Указывай всегда если пользователь назвал дату. Используется при add_expense, add_income, edit_transaction.",
 					},
 				},
 				"required": []string{"action"},
@@ -179,13 +179,23 @@ func (s *BudgetSkill) addTransaction(ctx context.Context, req budgetInput, typ s
 		return "", fmt.Errorf("amount must be positive")
 	}
 
+	date := time.Now()
+	if req.Date != "" {
+		for _, layout := range []string{"2006-01-02", "02.01.2006", "2006-01-02T15:04:05Z07:00"} {
+			if d, err := time.Parse(layout, req.Date); err == nil {
+				date = d
+				break
+			}
+		}
+	}
+
 	t := budget.Transaction{
 		ID:          uuid.New(),
 		Type:        typ,
 		Amount:      req.Amount,
 		Currency:    req.Currency,
 		Description: req.Description,
-		Date:        time.Now(),
+		Date:        date,
 	}
 
 	// Найти категорию по имени.
@@ -571,8 +581,8 @@ func formatPeriodName(p budget.Period) string {
 
 func currentMonthPeriod() budget.Period {
 	now := time.Now()
-	from := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.Local)
-	to := from.AddDate(0, 1, -1)
+	from := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(now.Year(), now.Month()+1, 1, 0, 0, 0, 0, time.UTC).Add(-time.Second)
 	return budget.Period{From: from, To: to}
 }
 
@@ -585,8 +595,8 @@ func parsePeriod(s string) budget.Period {
 	if err != nil {
 		return currentMonthPeriod()
 	}
-	from := time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, time.Local)
-	to := from.AddDate(0, 1, -1)
+	from := time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(t.Year(), t.Month()+1, 1, 0, 0, 0, 0, time.UTC).Add(-time.Second)
 	return budget.Period{From: from, To: to}
 }
 


### PR DESCRIPTION
## Bug
Все транзакции сохранялись с сегодняшней датой независимо от указанной пользователем. В `addTransaction` стояло `Date: time.Now()` — поле `req.Date` приходило от LLM но игнорировалось.

Следствие: запросы сводки за прошлые месяцы возвращали 0, хотя транзакции были введены.

## Fix
- `addTransaction`: парсим `req.Date` (форматы `YYYY-MM-DD` и `DD.MM.YYYY`), используем как дату транзакции
- `parsePeriod` / `currentMonthPeriod`: переход на UTC и корректный конец периода (`23:59:59` последнего дня) чтобы избежать timezone edge cases
- Manifest: уточнено описание поля `date` — применяется и для `add_expense`/`add_income`

## Существующие данные
Записи в БД с неправильными датами нужно исправить вручную через `edit_transaction` или напрямую в БД.

## Test plan
- [ ] «потратил 500 рублей 07.02.2026 на еду» → в БД дата `2026-02-07`
- [ ] «покажи сводку за февраль» → показывает транзакции с датами в феврале
- [ ] Без даты → используется сегодняшняя дата

🤖 Generated with [Claude Code](https://claude.com/claude-code)