### PR TITLE
chore(deploy): LLM_CHAT_MODEL=deepseek-v4-flash

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
               echo ""
               echo "LLM_PROVIDER=openai"
               echo "LLM_BASE_URL=https://api.deepseek.com/v1"
-              echo "LLM_CHAT_MODEL=deepseek-chat"
+              echo "LLM_CHAT_MODEL=deepseek-v4-flash"
               echo "LLM_TIMEOUT_SECONDS=30"
               echo "LLM_RETRY_COUNT=2"
               echo "LLM_RETRY_BASE_MS=500"


### PR DESCRIPTION
## Summary
Меняет имя модели в генерируемом на проде .env с `deepseek-chat` на `deepseek-v4-flash` чтобы Langfuse generation матчил pricing/cost (запись модели в Langfuse settings уже создана с этим именем).

DeepSeek API принимает оба имени как алиасы — функционально не меняется.

После merge GitHub Actions запустит deploy → systemctl restart simpleai → следующие LLM-вызовы пойдут с правильным model в Langfuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)